### PR TITLE
[ADD] 단서/의문점 버그 수정, 기능 추가

### DIFF
--- a/Sincere/Assets/Resources/GameData/dialogues.json
+++ b/Sincere/Assets/Resources/GameData/dialogues.json
@@ -1,0 +1,28 @@
+{
+  "dialogues": [
+    {
+      "dialogueID": "dialogue_001",
+      "characterName": ["캐릭터1","캐릭터2","캐릭터1"],
+      "characterSprite": ["Character/Standing01","Character/Standing02","Character/Standing01"],
+      "dialogue": ["오브젝트1 대사1","오브젝트1 대사2","오브젝트1 대사3"],
+      "clueTiming": 100,
+      "questionTiming": 100
+    },
+    {
+      "dialogueID": "dialogue_002",
+      "characterName": ["캐릭터1","캐릭터2","캐릭터1","캐릭터2"],
+      "characterSprite": ["Character/Standing01","Character/Standing02","Character/Standing01","Character/Standing02"],
+      "dialogue": ["오브젝트2 대사1","오브젝트2 대사2 with 단서","오브젝트2 대사3 with 의문점","오브젝트2 대사4"],
+      "clueTiming": 1,
+      "questionTiming": 2
+    },
+    {
+      "dialogueID": "dialogue_003",
+      "characterName": ["캐릭터2","캐릭터1","캐릭터2","캐릭터1"],
+      "characterSprite": ["Character/Standing02","Character/Standing01","Character/Standing02","Character/Standing01"],
+      "dialogue": ["오브젝트3 대사1","오브젝트3 대사2 with 의문점","오브젝트3 대사3 with 단서","오브젝트3 대사4"],
+      "clueTiming": 2,
+      "questionTiming": 1
+    }
+  ]
+}

--- a/Sincere/Assets/Resources/GameData/dialogues.json.meta
+++ b/Sincere/Assets/Resources/GameData/dialogues.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 38c6b2f01caead84183a362e469719ed
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Sincere/Assets/Resources/GameData/objects.json
+++ b/Sincere/Assets/Resources/GameData/objects.json
@@ -4,18 +4,21 @@
       "objectID": "object_001",
       "objectClue": "",
       "objectQuestion": "",
+      "dialogueID": "dialogue_001",
       "objectType": "DialogueOnly"
     },
     {
       "objectID": "object_002",
       "objectClue": "clue_001",
       "objectQuestion": "question_001",
+      "dialogueID": "dialogue_002",
       "objectType": "ClueAndDestroy"
     },
     {
       "objectID": "object_003",
       "objectClue": "clue_002",
       "objectQuestion": "question_002",
+      "dialogueID": "dialogue_003",
       "objectType": "ClueAndKeep"
     }
   ]

--- a/Sincere/Assets/Scenes/MainScene.unity
+++ b/Sincere/Assets/Scenes/MainScene.unity
@@ -233,9 +233,9 @@ RectTransform:
   - {fileID: 1780102498}
   m_Father: {fileID: 1625959320}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 960, y: -675}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 950, y: 200}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &50730596
@@ -676,7 +676,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 100
+  m_SortingOrder: 10
   m_TargetDisplay: 0
 --- !u!1 &302617907
 GameObject:
@@ -3233,7 +3233,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 0
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 1
+  m_SortingOrder: 200
   m_TargetDisplay: 0
 --- !u!224 &568918943
 RectTransform:
@@ -4518,18 +4518,6 @@ MonoBehaviour:
   characterImage: {fileID: 1582715782}
   nameText: {fileID: 929752183}
   dialogueText: {fileID: 1395964341}
-  dialogues:
-  - "\uB300\uC0AC1\uBC88"
-  - "\uB300\uC0AC2\uBC88"
-  - "\uB300\uC0AC3\uBC88"
-  characterNames:
-  - "\uCE90\uB9AD\uD1301"
-  - "\uCE90\uB9AD\uD1302"
-  - "\uCE90\uB9AD\uD1301"
-  characterSprites:
-  - {fileID: 21300000, guid: 8ba74c9d328d3ff45a272b369ff5410e, type: 3}
-  - {fileID: 21300000, guid: cb3ece1d2af65d54e9060c26f320da2f, type: 3}
-  - {fileID: 21300000, guid: 8ba74c9d328d3ff45a272b369ff5410e, type: 3}
 --- !u!4 &1109401045
 Transform:
   m_ObjectHideFlags: 0
@@ -5008,7 +4996,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 0
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 20
+  m_SortingOrder: 100
   m_TargetDisplay: 0
 --- !u!224 &1314027650
 RectTransform:
@@ -5065,9 +5053,9 @@ RectTransform:
   - {fileID: 1704719599}
   m_Father: {fileID: 1625959320}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 960, y: -405}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 950, y: 200}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1390457083
@@ -5809,9 +5797,9 @@ RectTransform:
   - {fileID: 1776957178}
   m_Father: {fileID: 1625959320}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 960, y: -135}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 950, y: 200}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1525455010
@@ -6080,9 +6068,9 @@ RectTransform:
   - {fileID: 1207181798}
   m_Father: {fileID: 1625959320}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 960, y: -945}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 950, y: 200}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1600984114
@@ -6186,7 +6174,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &1625959320
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Sincere/Assets/Scripts/Dialogue/Dialogue.cs
+++ b/Sincere/Assets/Scripts/Dialogue/Dialogue.cs
@@ -4,19 +4,16 @@ using System;
 
 public class Dialogue : MonoBehaviour
 {
-    [Header("UI")]
     [SerializeField] private GameObject dialogueUI; //대화창 전체
     [SerializeField] private Image characterImage; //캐릭터 스프라이트
     [SerializeField] private Text nameText; //캐릭터 이름
     [SerializeField] private Text dialogueText; //대사 텍스트
 
-    [Header("데이터")]
-    [SerializeField] private string[] dialogues; // 대사 배열
-    [SerializeField] private string[] characterNames; // 캐릭터 이름 배열
-    [SerializeField] private Sprite[] characterSprites; // 캐릭터 스프라이트 배열
-
+    private DialogueData currentDialogueData;
     private int currentDialogueIndex = 0;
     private Action DialogueEndCallback;
+    private Action<int> OnClueTimingCallback;
+    private Action<int> OnQuestionTimingCallback;
 
 
     void Start()
@@ -41,10 +38,34 @@ public class Dialogue : MonoBehaviour
         DialogueEndCallback = callback;
     }
 
-
-    //시작 (InteractableObject에서 호출)
-    public void StartDialogue()
+    // 단서/의문점 습득 콜백 설정
+    public void SetTimingCallbacks(Action<int> clueCallback, Action<int> questionCallback)
     {
+        OnClueTimingCallback = clueCallback;
+        OnQuestionTimingCallback = questionCallback;
+    }
+
+
+
+    //시작 (InvestObject에서 호출)
+    public void StartDialogue(string dialogueID)
+    {
+        // DataManager에서 대화 데이터 로드
+        if (DataManager.instance == null)
+        {
+            Debug.LogError("DataManager가 없습니다!");
+            return;
+        }
+
+        // dialogueID로 데이터 찾기
+        currentDialogueData = DataManager.instance.GetDialogueByID(dialogueID);
+
+        if (currentDialogueData == null)
+        {
+            Debug.LogError($"대화 ID '{dialogueID}'를 찾을 수 없습니다!");
+            return;
+        }
+
         currentDialogueIndex = 0;
 
         if (dialogueUI != null)
@@ -61,7 +82,19 @@ public class Dialogue : MonoBehaviour
     {
         currentDialogueIndex++;
 
-        if (currentDialogueIndex >= dialogues.Length)
+        // 현재 대사 인덱스가 단서 타이밍과 일치하면
+        if (currentDialogueData.clueTiming == currentDialogueIndex)
+        {
+            OnClueTimingCallback?.Invoke(currentDialogueIndex);
+        }
+
+        // 현재 대사 인덱스가 의문점 타이밍과 일치하면
+        if (currentDialogueData.questionTiming == currentDialogueIndex)
+        {
+            OnQuestionTimingCallback?.Invoke(currentDialogueIndex);
+        }
+
+        if (currentDialogueIndex >= currentDialogueData.dialogue.Length)
         {
             EndDialogue();
         }
@@ -75,24 +108,37 @@ public class Dialogue : MonoBehaviour
     // 현재 대사 표시
     private void ShowDialogue()
     {
-        if (dialogues.Length == 0) return;
-
-        // 캐릭터 스프라이트 표시
-        if (characterImage != null && characterSprites.Length > currentDialogueIndex)
-        {
-            characterImage.sprite = characterSprites[currentDialogueIndex];
-        }
+        if (currentDialogueData == null || currentDialogueData.dialogue.Length == 0) return;
 
         // 캐릭터 이름 표시
-        if (nameText != null && characterNames.Length > currentDialogueIndex)
+        if (nameText != null && currentDialogueData.characterName.Length > currentDialogueIndex)
         {
-            nameText.text = characterNames[currentDialogueIndex];
+            nameText.text = currentDialogueData.characterName[currentDialogueIndex];
         }
 
         // 대사 텍스트 표시
         if (dialogueText != null)
         {
-            dialogueText.text = dialogues[currentDialogueIndex];
+            dialogueText.text = currentDialogueData.dialogue[currentDialogueIndex];
+        }
+
+        // 캐릭터 스프라이트 표시
+        if (characterImage != null && currentDialogueData.characterSprite != null
+        && currentDialogueData.characterSprite.Length > currentDialogueIndex)
+        {
+            string spritePath = currentDialogueData.characterSprite[currentDialogueIndex];
+            if (!string.IsNullOrEmpty(spritePath))
+            {
+                Sprite sprite = Resources.Load<Sprite>(spritePath);
+                if (sprite != null)
+                {
+                    characterImage.sprite = sprite;
+                }
+                else
+                {
+                    Debug.LogWarning($"스프라이트를 찾을 수 없습니다");
+                }
+            }
         }
     }
 
@@ -105,8 +151,9 @@ public class Dialogue : MonoBehaviour
         }
 
         currentDialogueIndex = 0;
+        currentDialogueData = null;
 
-        DialogueEndCallback.Invoke();
+        DialogueEndCallback?.Invoke();
         DialogueEndCallback = null;
     }
 }

--- a/Sincere/Assets/Scripts/Note/NoteController.cs
+++ b/Sincere/Assets/Scripts/Note/NoteController.cs
@@ -65,6 +65,7 @@ public class NoteController : MonoBehaviour
         if (DataManager.instance != null)
         {
             List<ClueData> clues = DataManager.instance.GetAcquiredClues();
+            List<QuestionData> questions = DataManager.instance.GetAcquiredQuestions();
         }
         UpdateClueList();
         UpdateQuestionList();

--- a/Sincere/Assets/Scripts/ObjectInteract/InvestObject.cs
+++ b/Sincere/Assets/Scripts/ObjectInteract/InvestObject.cs
@@ -30,6 +30,12 @@ public class InvestObject : MonoBehaviour
         {
             Debug.LogWarning("Player 오브젝트가 할당되지 않았습니다!");
         }
+
+        // 이미 파괴된 오브젝트 삭제
+        if (DataManager.instance != null && DataManager.instance.IsObjectDestroyed(objectID))
+        {
+            Destroy(gameObject);
+        }
     }
 
     void Update()
@@ -139,6 +145,13 @@ public class InvestObject : MonoBehaviour
                     //타입2 : 상호작용 시 대사창→단서 업데이트→맵의 오브젝트 삭제/수정
                     UpdateClue();
                     UpdateQuestion();
+
+                    // 파괴 기록
+                    if (DataManager.instance != null)
+                    {
+                        DataManager.instance.RegisterDestroyedObject(objectID);
+                    }
+
                     Destroy(gameObject);
                     break;
 

--- a/Sincere/Assets/Scripts/ObjectInteract/InvestObject.cs
+++ b/Sincere/Assets/Scripts/ObjectInteract/InvestObject.cs
@@ -88,12 +88,36 @@ public class InvestObject : MonoBehaviour
     {
         HideUI();
 
-        // 대화가 끝났을 때 호출될 콜백 설정
-        dialogue.SetOnDialogueEnd(OnDialogueEnd);
-        dialogue.StartDialogue();
+        // 대화 시작 (dialogueID 전달)
+        if (dialogue != null)
+        {
+            // 콜백 설정
+            dialogue.SetOnDialogueEnd(OnDialogueEnd);
+            dialogue.SetTimingCallbacks(OnClueTiming, OnQuestionTiming);
+
+            // JSON에서 dialogueID 가져오기
+            ObjectData objData = DataManager.instance.allObjects.Find(o => o.objectID == objectID);
+            if (objData != null && !string.IsNullOrEmpty(objData.dialogueID))
+            {
+                dialogue.StartDialogue(objData.dialogueID);
+            }
+        }
     }
 
-    
+
+    // 단서 습득 타이밍
+    private void OnClueTiming(int timing)
+    {
+        UpdateClue();
+    }
+
+    // 의문점 습득 타이밍
+    private void OnQuestionTiming(int timing)
+    {
+        UpdateQuestion();
+    }
+
+    // 대화 종료 타이밍
     private void OnDialogueEnd()
     {
         if (!string.IsNullOrEmpty(objectID))
@@ -114,12 +138,14 @@ public class InvestObject : MonoBehaviour
                 case "ClueAndDestroy":
                     //타입2 : 상호작용 시 대사창→단서 업데이트→맵의 오브젝트 삭제/수정
                     UpdateClue();
+                    UpdateQuestion();
                     Destroy(gameObject);
                     break;
 
                 case "ClueAndKeep":
                     //타입3 : 상호작용 시 대사창→단서 업데이트→맵의 오브젝트 유지
                     UpdateClue();
+                    UpdateQuestion();
                     break;
             }
         }
@@ -131,12 +157,26 @@ public class InvestObject : MonoBehaviour
     }
 
 
-    // 단서,의문점 업데이트
+    // 단서 업데이트
     private void UpdateClue()
     {
         if (!string.IsNullOrEmpty(objectID))
         {
             DataManager.instance.UpdateObjectClue(objectID);
+        }
+        else
+        {
+            Debug.Log("오브젝트ID 설정 안됨");
+            return;
+        }
+    }
+
+    // 의문점 업데이트
+    private void UpdateQuestion()
+    {
+        if (!string.IsNullOrEmpty(objectID))
+        {
+            DataManager.instance.UpdateObjectQuestion(objectID);
         }
         else
         {

--- a/Sincere/Assets/Scripts/SaveLoad/DataManager.cs
+++ b/Sincere/Assets/Scripts/SaveLoad/DataManager.cs
@@ -16,6 +16,7 @@ public class ObjectData
     public string objectID;
     public string objectClue;
     public string objectQuestion;
+    public string dialogueID;
     public string objectType;
 }
 [System.Serializable]
@@ -35,6 +36,16 @@ public class QuestionData
     public string questionName;
     public string questionDescription;
     public string questionClue;
+}
+[System.Serializable]
+public class DialogueData
+{
+    public string dialogueID;
+    public string[] characterName;
+    public string[] characterSprite;
+    public string[] dialogue;
+    public int clueTiming;
+    public int questionTiming;
 }
 [System.Serializable]
 public class GameData
@@ -59,6 +70,7 @@ public class DataManager : MonoBehaviour
     public List<ObjectData> allObjects = new List<ObjectData>();
     public List<ClueData> allClues = new List<ClueData>();
     public List<QuestionData> allQuestions = new List<QuestionData>();
+    public List<DialogueData> allDialogues = new List<DialogueData>();
 
     public string savePath;
     public int slot;
@@ -121,6 +133,21 @@ public class DataManager : MonoBehaviour
             allQuestions = questionList.questions;
         }
         else { Debug.Log($"의문점 데이터 로드 실패"); }
+
+        // Resources/GameData/dialogues.json
+        TextAsset dialoguesJson = Resources.Load<TextAsset>("GameData/dialogues");
+        if (dialoguesJson != null)
+        {
+            DialogueDataList dialoguesList = JsonUtility.FromJson<DialogueDataList>(dialoguesJson.text);
+            allDialogues = dialoguesList.dialogues;
+        }
+        else { Debug.Log($"대사 데이터 로드 실패"); }
+    }
+
+    // dialogueID로 대화 데이터 찾기
+    public DialogueData GetDialogueByID(string dialogueID)
+    {
+        return allDialogues.Find(d => d.dialogueID == dialogueID);
     }
 
 
@@ -177,7 +204,7 @@ public class DataManager : MonoBehaviour
 
 
 
-    // 오브젝트 상호작용 시 단서/의문점 업데이트
+    // 오브젝트 상호작용 시 단서 업데이트
     public void UpdateObjectClue(string objectID)
     {
         // 1. 오브젝트 데이터 찾기
@@ -197,8 +224,20 @@ public class DataManager : MonoBehaviour
                 AddClue(clue);
             }
         }
+    }
 
-        // 3. 연관된 의문점 추가
+    // 오브젝트 상호작용 시 의문점 업데이트
+    public void UpdateObjectQuestion(string objectID)
+    {
+        // 1. 오브젝트 데이터 찾기
+        ObjectData obj = allObjects.Find(o => o.objectID == objectID);
+        if (obj == null)
+        {
+            Debug.LogWarning($"오브젝트 ID '{objectID}'를 찾을 수 없습니다.");
+            return;
+        }
+
+        // 2. 연관된 의문점 추가
         if (obj.objectQuestion != null)
         {
             QuestionData question = allQuestions.Find(q => q.questionID == obj.objectQuestion);
@@ -212,19 +251,13 @@ public class DataManager : MonoBehaviour
 
 
     // 단서 습득
-    public void AddClue(ClueData clueID)
+    public void AddClue(ClueData clue)
     {
-        if (!acquiredClues.Contains(clueID))
+        if (!acquiredClues.Exists(c => c.clueID == clue.clueID))
         {
-            acquiredClues.Add(clueID);
-            print($"단서 추가: {clueID}");
+            acquiredClues.Add(clue);
+            print($"단서 추가: {clue.clueID}");
         }
-    }
-
-    // 단서 획득 여부 확인
-    public bool HasClue(ClueData clueID)
-    {
-        return acquiredClues.Contains(clueID);
     }
 
     // 전체 습득한 단서 불러오기
@@ -236,19 +269,13 @@ public class DataManager : MonoBehaviour
 
 
     // 의문점 습득
-    public void AddQuestion(QuestionData questionID)
+    public void AddQuestion(QuestionData question)
     {
-        if (!acquiredQuestions.Contains(questionID))
+        if (!acquiredQuestions.Exists(q => q.questionID == question.questionID))
         {
-            acquiredQuestions.Add(questionID);
-            print($"의문점 추가: {questionID}");
+            acquiredQuestions.Add(question);
+            print($"의문점 추가: {question.questionID}");
         }
-    }
-
-    // 의문점 획득 여부 확인
-    public bool HasQuestion(QuestionData questionID)
-    {
-        return acquiredQuestions.Contains(questionID);
     }
 
     // 전체 습득한 의문점 불러오기
@@ -277,4 +304,10 @@ public class ClueDataList
 public class QuestionDataList
 {
     public List<QuestionData> questions;
+}
+
+[System.Serializable]
+public class DialogueDataList
+{
+    public List<DialogueData> dialogues;
 }

--- a/Sincere/Assets/Scripts/SaveLoad/DataManager.cs
+++ b/Sincere/Assets/Scripts/SaveLoad/DataManager.cs
@@ -66,6 +66,7 @@ public class DataManager : MonoBehaviour
 
     public List<ClueData> acquiredClues = new List<ClueData>();
     public List<QuestionData> acquiredQuestions = new List<QuestionData>();
+    public List<string> investedObjects = new List<string>();
 
     public List<ObjectData> allObjects = new List<ObjectData>();
     public List<ClueData> allClues = new List<ClueData>();
@@ -160,7 +161,8 @@ public class DataManager : MonoBehaviour
         {
             player = player,
             acquiredClues = acquiredClues,
-            acquiredQuestions = acquiredQuestions
+            acquiredQuestions = acquiredQuestions,
+            investedObjects = investedObjects
         };
 
         string savedData = JsonUtility.ToJson(saveData, true);  //데이터 -> JSON으로 변환
@@ -183,6 +185,7 @@ public class DataManager : MonoBehaviour
             player = saveData.player;
             acquiredClues = saveData.acquiredClues;
             acquiredQuestions = saveData.acquiredQuestions;
+            investedObjects = saveData.investedObjects;
         }
     }
 
@@ -282,6 +285,23 @@ public class DataManager : MonoBehaviour
     public List<QuestionData> GetAcquiredQuestions()
     {
         return new List<QuestionData>(acquiredQuestions);
+    }
+
+
+    // 오브젝트 파괴 기록
+    public void RegisterDestroyedObject(string objectID)
+    {
+        if (!investedObjects.Contains(objectID))
+        {
+            investedObjects.Add(objectID);
+            Debug.Log($"{objectID} 오브젝트 파괴");
+        }
+    }
+
+    // 오브젝트가 파괴되었는지 확인
+    public bool IsObjectDestroyed(string objectID)
+    {
+        return investedObjects.Contains(objectID);
     }
 }
 


### PR DESCRIPTION
## 작업 내용

> 단서, 의문점을 대사 중간에 습득하는 기능 추가
> 2번타입 오브젝트와의 상호작용 후 불러오기 시 오브젝트가 삭제되어있게 하는 기능 추가
> 대사 데이터 JSON화
> 단서, 의문점 중복저장 버그 수정

> 단서와 의문점 습득 현황은 DataManager의 inspector에 보이는 Acquired Clues, Acquired Questions 변수들 참고하시면 됩니다.

<br/>

## 스크린샷 첨부
<img width="1497" height="897" alt="스크린샷 2025-12-28 001225" src="https://github.com/user-attachments/assets/c1d5810a-0f08-4ad1-abd0-7a26b873bd91" />

<br/>

## 리뷰 요구사항 (선택)
> 
